### PR TITLE
Fix duplicate path resolution in PathExpander by using HashSet as intended

### DIFF
--- a/FluentCleaner/Services/PathExpander.cs
+++ b/FluentCleaner/Services/PathExpander.cs
@@ -69,12 +69,11 @@ public class PathExpander
     // installed under Program Files (x86).
     public List<string> ResolvePaths(string rawPath)
     {
-        var results = new List<string>();
+        var results = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         // Always resolve the primary path.
         ResolveRecursive(ExpandVariables(rawPath), results);
 
-        //!Fixed!---------------------------
         // If the path references %ProgramFiles%, also try %ProgramFiles(x86)%.
         // Use a HashSet to avoid duplicate results when both point to the same dir (32-bit OS).
         if (rawPath.Contains("%ProgramFiles%", StringComparison.OrdinalIgnoreCase))
@@ -82,14 +81,12 @@ public class PathExpander
             var x86Path = rawPath.Replace("%ProgramFiles%", "%ProgramFiles(x86)%",
                                           StringComparison.OrdinalIgnoreCase);
             var expanded = ExpandVariables(x86Path);
-            if (!results.Contains(expanded))
-                ResolveRecursive(expanded, results);
+            ResolveRecursive(expanded, results);
         }
-        //---------------------------
-        return results;
+        return results.ToList();
     }
 
-    private static void ResolveRecursive(string path, List<string> results)
+    private static void ResolveRecursive(string path, HashSet<string> results)
     {
         var parts = path.Split(new[] { '\\', '/' }, StringSplitOptions.None);
 


### PR DESCRIPTION
This PR aligns the code with the developer's original intent expressed in comments to use a HashSet for resolving paths and preventing duplicate results (e.g., when `%ProgramFiles%` and `%ProgramFiles(x86)%` point to the same directory).

The previous implementation used a `List<string>` and performed the check `if (!results.Contains(expanded))`, comparing the unresolved path template (with wildcards) to the list of resolved actual paths. This logic bug caused the check to always fail and add duplicates.

**Changes:**
- Changed `results` from `List<string>` to `HashSet<string>` internally.
- Removed the incorrect check `!results.Contains(expanded)`.
- Converted the final set back to `List<string>` via `.ToList()` before returning.