### PR TITLE
docs: add runtime troubleshooting guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,17 @@ FluentCleaner just gives you more control over what exactly gets cleaned
 </details>
 
 <details>
+<summary>FluentCleaner shows "Unknown Hard Error" or won't launch</summary>
+
+the modern version requires the exact [Windows App SDK 2.0.1 x64 runtime](https://aka.ms/windowsappsdk/2.0/2.0.1/windowsappruntimeinstall-x64.exe).
+an older or newer Windows App SDK runtime will not work.
+
+after installing it, restart Windows so the runtime can register properly.
+if the problem continues, add the exact error and your Windows version to [issue #85](https://github.com/builtbybel/FluentCleaner/issues/85).
+
+</details>
+
+<details>
 <summary>what even is winapp2.ini?</summary>
 
 a community-maintained database of cleaning rules for Windows apps,


### PR DESCRIPTION
## What changed

- add an FAQ entry for the "Unknown Hard Error" startup failure
- link the exact Windows App SDK 2.0.1 x64 runtime required by the modern build
- document the required restart and where to report remaining errors

## Why

The startup error is commonly caused by a Windows App SDK runtime version mismatch. The download table lists the dependency, but users encountering the error currently have to find the troubleshooting steps in issue comments.

## Impact

Users get the maintainer-confirmed recovery steps directly in the README. This is a documentation-only change and does not affect cleaning or application behavior.

## Validation

- `git diff --check`
- verified the runtime download link returns HTTP 200

Relates to #85
