### PR TITLE
fix: check x86 ProgramFiles in DetectionService for non-wildcard paths

### DIFF
--- a/FluentCleaner.Core/Services/DetectionService.cs
+++ b/FluentCleaner.Core/Services/DetectionService.cs
@@ -67,10 +67,7 @@ public class DetectionService
     {
         try
         {
-            var expanded = _expander.ExpandVariables(rawPath);
-            if (expanded.Contains('*') || expanded.Contains('?'))
-                return _expander.ResolvePaths(rawPath).Count > 0;
-            return File.Exists(expanded) || Directory.Exists(expanded);
+            return _expander.ResolvePaths(rawPath).Any(p => File.Exists(p) || Directory.Exists(p));
         }
         catch { return false; }
     }


### PR DESCRIPTION
Currently, CheckFile in DetectionService only invokes PathExpander.ResolvePaths when the path contains wildcards (* or ?). For literal paths, it checks File.Exists(expanded) against the 64-bit Program Files path only.

This causes 32-bit applications installed under %ProgramFiles(x86)% to fail detection when their DetectFile signature references %ProgramFiles% without wildcards.

Using ResolvePaths directly ensures both 64-bit and 32-bit Program Files locations are checked, matching the behavior described in PathExpander.